### PR TITLE
fix: enum타입을 db에 string으로 저장

### DIFF
--- a/src/main/java/ssgssak/ssgpointuser/domain/point/entity/ExchangePoint.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/entity/ExchangePoint.java
@@ -18,6 +18,7 @@ public class ExchangePoint {
     private Long id;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private ExchangeType type;
 
     @Column(nullable = false)

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/entity/GiftPoint.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/entity/GiftPoint.java
@@ -34,6 +34,7 @@ public class GiftPoint extends BaseTimeEntity {
     private Long receivePointId;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private GiftStatus status;
 
     @Column(nullable = false)


### PR DESCRIPTION
# 버그 해결 💊
point 도메인 - ExchangePoint와 GiftPoint에 Enum타입이 db에 int타입으로 들어가는 버그를 해결
 
# 스크린샷 🖼
 
<img width="858" alt="image" src="https://github.com/ssg-ssak/ssg-ssak-BE-user/assets/108791919/9b740c27-4904-4e93-a2f3-5d200be55f01">

<img width="584" alt="image" src="https://github.com/ssg-ssak/ssg-ssak-BE-user/assets/108791919/5a905b0d-7b51-46df-88be-2f3dae2b865f">

