### PR TITLE
refactor: ModelMapper로 entity 생성할 수 있도록 변경

### DIFF
--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/application/AuthServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/application/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package ssgssak.ssgpointuser.domain.auth.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import ssgssak.ssgpointuser.domain.auth.dto.AuthDeactivateSignUpDto;
 import ssgssak.ssgpointuser.domain.auth.dto.AuthSignUpDto;
@@ -20,6 +21,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AuthServiceImpl implements AuthService {
     private final UserRepository userRepository;
+    private final ModelMapper modelMapper;
 
     /**
      * 회원가입
@@ -27,21 +29,14 @@ public class AuthServiceImpl implements AuthService {
     public void signUp(AuthSignUpDto authSignUpDto) {
         String newUUID = generateUUID();
         User newUser = User.builder()
-                .userId(authSignUpDto.getUserId())
                 .userUUID(newUUID)
-                .userName(authSignUpDto.getUserName())
-                .userPassword(authSignUpDto.getUserPassword())
-                .email(authSignUpDto.getEmail())
-                .address(authSignUpDto.getAddress())
-                .phoneNumber(authSignUpDto.getPhoneNumber())
                 .barcodeNumber("init")
                 .build();
-        log.info("id : " + newUser.getId());
+        modelMapper.map(authSignUpDto,newUser);
         userRepository.save(newUser);
         String id = userRepository.findUserByUserUUID(newUUID).get().getId().toString();
         String newBarcode = generateBarcodeNumber(id);
         newUser.setNewBarcodeNumber(newBarcode);
-        log.info("barcode : " + newBarcode);
         userRepository.save(newUser);
     }
 

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/application/PointServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/application/PointServiceImpl.java
@@ -218,39 +218,53 @@ public class PointServiceImpl implements PointService {
                                             String startDay,
                                             String endDay,
                                             String uuid) {
-        // String으로 들어온 날짜를 LocalDateTime으로 바꿈
-        LocalDateTime sttDay = changeDate(startDay);
-        LocalDateTime eddDay = changeDate(endDay);
-        List<Point> pointList;
+        List<Point> pointList = null;
 
-        // 1. 전체 조회
-        if (type == null && used == null) {
-            pointList = pointRepository.findAllByUserUUIDAndCreateAtBetween(uuid, sttDay, eddDay);
-        }
-        // 2. 전체 타입을, 선택한 사용유무로 검색
-        else if (type == null && used != null) {
-            pointList = pointRepository.findAllByUserUUIDAndUsedAndCreateAtBetween(uuid, used, sttDay, eddDay);
-        }
-        // 3. 선택한 타입을, 전체 사용유무로 검색
-        else if (type != null && used == null) {
-            // 일반 타입이라면, 이벤트를 제외하고 검색한다
-            if (type == PointType.GENERAL) {
-                pointList = pointRepository.findAllByUserUUIDAndTypeNotAndCreateAtBetween(uuid, PointType.EVENT, sttDay, eddDay);
+        // 기간이 정해져 있을 때
+        if (startDay != null && endDay != null) {
+            // String으로 들어온 날짜를 LocalDateTime으로 바꿈
+            LocalDateTime sttDay = changeDate(startDay);
+            LocalDateTime eddDay = changeDate(endDay);
+            // 1. 전체 조회
+            if (type == null && used == null) {
+                pointList = pointRepository.findAllByUserUUIDAndCreateAtBetween(uuid, sttDay, eddDay);
             }
-            // 이벤트 타입이라면, 이벤트만 검색한다
+            // 2. 전체 타입을, 선택한 사용유무로 검색
+            else if (type == null && used != null) {
+                pointList = pointRepository.findAllByUserUUIDAndUsedAndCreateAtBetween(uuid, used, sttDay, eddDay);
+            }
+            // 3. 선택한 타입을, 전체 사용유무로 검색
+            else if (type != null && used == null) {
+                // 일반 타입이라면, 이벤트를 제외하고 검색한다
+                if (type == PointType.GENERAL) {
+                    pointList = pointRepository.findAllByUserUUIDAndTypeNotAndCreateAtBetween(uuid, PointType.EVENT, sttDay, eddDay);
+                }
+                // 이벤트 타입이라면, 이벤트만 검색한다
+                else {
+                    pointList = pointRepository.findAllByUserUUIDAndTypeAndCreateAtBetween(uuid, type, sttDay, eddDay);
+                }
+            }
+            // 4. 선택한 타입과, 선택한 사용유무로 검색
             else {
-                pointList = pointRepository.findAllByUserUUIDAndTypeAndCreateAtBetween(uuid, type, sttDay, eddDay);
+                // 일반 타입이라면, 이벤트를 제외하고 검색한다
+                if (type == PointType.GENERAL) {
+                    pointList = pointRepository.findAllByUserUUIDAndTypeNotAndUsedAndCreateAtBetween(uuid, PointType.EVENT, used, sttDay, eddDay);
+                }
+                // 이벤트 타입이라면, 이벤트만 검색한다
+                else {
+                    pointList = pointRepository.findAllByUserUUIDAndTypeAndUsedAndCreateAtBetween(uuid, type, used, sttDay, eddDay);
+                }
             }
         }
-        // 4. 선택한 타입과, 선택한 사용유무로 검색
+        // 기간 없이, 전체 기간을 조회할때 -> 일단은 선물포인트만
         else {
-            // 일반 타입이라면, 이벤트를 제외하고 검색한다
-            if (type == PointType.GENERAL) {
-                pointList = pointRepository.findAllByUserUUIDAndTypeNotAndUsedAndCreateAtBetween(uuid, PointType.EVENT, used, sttDay, eddDay);
+            // 사용유무 관계없이 전체를 검색
+            if (type == PointType.GIFT && used == null) {
+                pointList = pointRepository.findAllByUserUUIDAndType(uuid, type);
             }
-            // 이벤트 타입이라면, 이벤트만 검색한다
-            else {
-                pointList = pointRepository.findAllByUserUUIDAndTypeAndUsedAndCreateAtBetween(uuid, type, used, sttDay, eddDay);
+            // 사용유무에 따라서 검색
+            else if (type == PointType.GIFT && used != null) {
+                pointList = pointRepository.findAllByUserUUIDAndTypeAndUsed(uuid, type, used);
             }
         }
         // 적립/사용 포인트 계산

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/entity/StorePoint.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/entity/StorePoint.java
@@ -21,9 +21,9 @@ public class StorePoint {
     private Long pointId;
 
     @Column
-    private Long receipt_id;
+    private Long receiptId;
 
     @Column(nullable = false)
-    private Long store_id;
+    private Long storeId;
 
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/infrastructure/PointRepository.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/infrastructure/PointRepository.java
@@ -21,6 +21,8 @@ public interface PointRepository extends JpaRepository<Point, Long> {
      * 5. 기간별, 선택한 타입을, 전체 사용유무에 따라서 조회
      * 6. 기간별, 일반 타입(EVENT 제외)을, 선택한 사용유무에 따라서 조회
      * 7. 기간별, 선택한 타입을, 선택한 사용유무에 따라서 조회
+     * 8. 기간없이, 선물 포인트만, 사용 유무에 관계없이 조회
+     * 9. 기간없이, 선물 포인트만, 사용 유무에 따라서 조회
      */
 
     // 1. 유저의 가장 최신 Point 조회
@@ -44,5 +46,10 @@ public interface PointRepository extends JpaRepository<Point, Long> {
     //7. 기간별, 선택한 타입을, 선택한 사용유무에 따라서 조회
     List<Point> findAllByUserUUIDAndTypeAndUsedAndCreateAtBetween(String uuid, PointType type, Boolean used, LocalDateTime stt, LocalDateTime end);
 
+    //8. 기간없이, 선물 포인트만, 사용 유무에 관계없이 조회
+    List<Point> findAllByUserUUIDAndType(String userUUID, PointType type);
+
+    //9. 기간없이, 선물 포인트만, 사용 유무에 따라서 조회
+    List<Point> findAllByUserUUIDAndTypeAndUsed(String uuid, PointType type, Boolean used);
 
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/presentation/PointController.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/presentation/PointController.java
@@ -80,10 +80,10 @@ public class PointController {
 
     // 7. 포인트 기간별로 조회하기
     @GetMapping("/list")
-    public ResponseEntity<PointListOutVo> searchPointList(@RequestParam(value = "type", required = false) PointType type,
-                                                          @RequestParam(value = "used", required = false) Boolean used,
-                                                          @RequestParam String startDay,
-                                                          @RequestParam String endDay,
+    public ResponseEntity<PointListOutVo> searchPointList(@RequestParam(required = false) PointType type,
+                                                          @RequestParam(required = false) Boolean used,
+                                                          @RequestParam(required = false) String startDay,
+                                                          @RequestParam(required = false) String endDay,
                                                           @RequestParam String uuid) {
         PointListResponseDto responseDto = pointService.pointSearch(type,used,startDay,endDay,uuid);
         PointListOutVo outVo = modelMapper.map(responseDto, PointListOutVo.class);

--- a/src/main/java/ssgssak/ssgpointuser/domain/user/entity/User.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/user/entity/User.java
@@ -1,10 +1,7 @@
 package ssgssak.ssgpointuser.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import ssgssak.ssgpointuser.global.common.entity.BaseTimeEntity;
 
 import java.time.LocalDateTime;
@@ -15,6 +12,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 @Table
+@ToString
 public class User extends BaseTimeEntity {
     // entity에 unique를 할 필요가 없음. 어차피 중복 검사해서 들어오는 값
     // DDD관점에서는 비즈니스 로직을 엔티티에 작성해도 괜찮음, 고려해볼것

--- a/src/main/java/ssgssak/ssgpointuser/global/config/app/AppConfig.java
+++ b/src/main/java/ssgssak/ssgpointuser/global/config/app/AppConfig.java
@@ -1,6 +1,7 @@
 package ssgssak.ssgpointuser.global.config.app;
 
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +13,7 @@ public class AppConfig {
         ModelMapper modelMapper = new ModelMapper();
         modelMapper.getConfiguration()
                 .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
+                .setMatchingStrategy(MatchingStrategies.STRICT)
                 .setFieldMatchingEnabled(true);
         return modelMapper;
     }


### PR DESCRIPTION
# 리팩토링 🛠
global, appconfig - ModelMapper에서 setMatchingStrategy를 바꿈으로써 dto-entity 변환시 발생하던 문제를 해결 따라서 entity 생성 가능
<br>

- [Error] ModelMapper로 Entity를 생성하는데, mapping이 안되네?
    - 상황 : 
    modelMapper를 사용해서 AuthSignUpDto → User로 변환하는데 mapping에러가 발생
    - 에러 코드 : 
    Converter org.modelmapper.internal.converter.NumberConverter@48580010 failed to convert java.lang.String to java.lang.Long.
    - 이유 : 
    ModelMapper의 기본 매칭 전략 때문
    MatchingStrategies.STANDARD는 소스-목표객체 간 필드명이 완전히 같을 필요가 없이, 일부만 일치하거나 유사하면 매핑을 시도한다
    따라서 String userId라는 필드와 Long Id필드를 매핑 시키려고 했지만 타입이 달라서 에러가 발생한 것이다
    - 해결방법 :
    MatchingStrategies를 STANDARD에서 STRICT로 바꾸고 해결
    STRICT는 소스-목표객체간 필드명이 정확히 동일한 필드만 매핑을 시도한다!
 
 
# 비고 ✏
추후에 나머지 엔티티 생성부분도 모두 모델매퍼를 사용하도록 변경할 예정입니다