### PR TITLE
feat: login기능 생성 및 버그 수정

### DIFF
--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/dto/AuthLoginRequestDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/dto/AuthLoginRequestDto.java
@@ -1,0 +1,15 @@
+package ssgssak.ssgpointuser.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthLoginRequestDto {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/dto/AuthLoginResponseDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/dto/AuthLoginResponseDto.java
@@ -1,0 +1,14 @@
+package ssgssak.ssgpointuser.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthLoginResponseDto {
+    private String token;
+}

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/dto/AuthSignUpDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/dto/AuthSignUpDto.java
@@ -2,7 +2,7 @@ package ssgssak.ssgpointuser.domain.auth.dto;
 
 import lombok.*;
 
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetails.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetails.java
@@ -23,7 +23,7 @@ public class CustomUserDetails implements UserDetails {
      */
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(user.getRoll().name()));
+        return List.of(new SimpleGrantedAuthority(user.getRoll().toString()));
     }
 
     @Override

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetails.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetails.java
@@ -31,9 +31,13 @@ public class CustomUserDetails implements UserDetails {
         return user.getUserPassword();
     }
 
-    // token에 user를 구분지을 userUUID를 넣어서 사용한다
     @Override
     public String getUsername() {
+        return user.getUserId();
+    }
+
+    // token에 user를 구분지을 userUUID를 넣어서 사용한다
+    public String getUserUUID() {
         return user.getUserUUID();
     }
 

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetailsService.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package ssgssak.ssgpointuser.domain.auth.entity;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -12,6 +13,7 @@ import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
@@ -22,6 +24,7 @@ public class CustomUserDetailsService implements UserDetailsService {
      */
     @Override
     public CustomUserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        log.info("로그인아이디 : " + loginId);
         User user = userRepository.findByUserId(loginId).orElseThrow(()-> new NoSuchElementException());
         return new CustomUserDetails(user);
     }

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetailsService.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/entity/CustomUserDetailsService.java
@@ -17,12 +17,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     /**
-     * 로그인시 전달받은 uuid로 유저를 가져온다
+     * 로그인시 전달받은 login ID로 유저를 가져온다
      * 이후, 가져온 유저를 이용해 userDetails를 생성한다
      */
     @Override
-    public CustomUserDetails loadUserByUsername(String uuid) throws UsernameNotFoundException {
-        User user = userRepository.findUserByUserUUID(uuid).orElseThrow(()-> new NoSuchElementException());
+    public CustomUserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        User user = userRepository.findByUserId(loginId).orElseThrow(()-> new NoSuchElementException());
         return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/presentation/AuthController.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/presentation/AuthController.java
@@ -3,11 +3,17 @@ package ssgssak.ssgpointuser.domain.auth.presentation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ssgssak.ssgpointuser.domain.auth.application.AuthServiceImpl;
 import ssgssak.ssgpointuser.domain.auth.dto.AuthDeactivateSignUpDto;
+import ssgssak.ssgpointuser.domain.auth.dto.AuthLoginRequestDto;
+import ssgssak.ssgpointuser.domain.auth.dto.AuthLoginResponseDto;
 import ssgssak.ssgpointuser.domain.auth.dto.AuthSignUpDto;
 import ssgssak.ssgpointuser.domain.auth.vo.AuthDeactivateSignUpVo;
+import ssgssak.ssgpointuser.domain.auth.vo.AuthLoginInVo;
+import ssgssak.ssgpointuser.domain.auth.vo.AuthLoginOutVo;
 import ssgssak.ssgpointuser.domain.auth.vo.AuthSignUpVo;
 
 @RestController
@@ -19,8 +25,13 @@ public class AuthController {
     private final ModelMapper modelMapper;
 
     /**
-     * 회원 가입
+     * Auth
+     * 1. 회원가입
+     * 2. 회원탈퇴
+     * 3. 로그인
      */
+
+    // 1. 회원가입
     @PostMapping("/sign-up")
     public void authSignUp(@RequestBody AuthSignUpVo authSignUpVo) {
         log.info("Vo" + authSignUpVo);
@@ -29,13 +40,19 @@ public class AuthController {
         authService.signUp(authSignUpDto);
     }
 
-    /**
-     * 회원 탈퇴
-     */
+    // 2. 회원탈퇴
     @PutMapping("/deactivate-account")
     public void deactivateAccount(@RequestBody AuthDeactivateSignUpVo deactivateVo) {
         AuthDeactivateSignUpDto deactivateDto = modelMapper.map(deactivateVo, AuthDeactivateSignUpDto.class);
         authService.deactivateAccount(deactivateDto,deactivateVo.getUserUUID());
+    }
+
+    // 3. 로그인
+    @PostMapping("/log-in")
+    public ResponseEntity<AuthLoginOutVo> login(@RequestBody AuthLoginInVo inVo) {
+        AuthLoginResponseDto responseDto = authService.userLogin(modelMapper.map(inVo, AuthLoginRequestDto.class));
+        AuthLoginOutVo outVo = modelMapper.map(responseDto, AuthLoginOutVo.class);
+        return new ResponseEntity<>(outVo, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/vo/AuthLoginInVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/vo/AuthLoginInVo.java
@@ -1,0 +1,9 @@
+package ssgssak.ssgpointuser.domain.auth.vo;
+
+import lombok.Getter;
+
+@Getter
+public class AuthLoginInVo {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/ssgssak/ssgpointuser/domain/auth/vo/AuthLoginOutVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/auth/vo/AuthLoginOutVo.java
@@ -1,0 +1,14 @@
+package ssgssak.ssgpointuser.domain.auth.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthLoginOutVo {
+    private String token;
+}

--- a/src/main/java/ssgssak/ssgpointuser/domain/user/entity/Roll.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/user/entity/Roll.java
@@ -1,6 +1,9 @@
 package ssgssak.ssgpointuser.domain.user.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum Roll {
     ADMIN,
-    USER
+    USER;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/user/entity/User.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package ssgssak.ssgpointuser.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import ssgssak.ssgpointuser.global.common.entity.BaseTimeEntity;
 
 import java.time.LocalDateTime;
@@ -64,6 +65,8 @@ public class User extends BaseTimeEntity {
      * 3. 포인트pw 변경 : pointPassword 변경
      * 4. 회원탈퇴 : softDelete 추가
      * 5. 바코드 설정
+     * 6. 비밀번호 해싱
+     * 7. 유저 Roll 설정
      */
 
     // 1. 회원정보 수정
@@ -90,5 +93,16 @@ public class User extends BaseTimeEntity {
     // 5. 바코드 설정
     public void setNewBarcodeNumber(String barcodeNumber) {
         this.barcodeNumber = barcodeNumber;
+    }
+
+    // 6. 비밀번호 해싱
+    public void hashPassword(String userPassword) {
+        this.userPassword = new BCryptPasswordEncoder().encode(userPassword);
+    }
+
+    // 7. 유저 Roll 설정
+    @PostPersist
+    public void setUserRoll() {
+        this.roll = Roll.USER;
     }
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/user/infrastructure/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByPhoneNumber(String phoneNumber);
 
+    Optional<User> findByUserId(String userId);
+
 }

--- a/src/main/java/ssgssak/ssgpointuser/global/common/exception/UnAuthorizedException.java
+++ b/src/main/java/ssgssak/ssgpointuser/global/common/exception/UnAuthorizedException.java
@@ -1,0 +1,23 @@
+package ssgssak.ssgpointuser.global.common.exception;
+
+public class UnAuthorizedException extends RuntimeException{
+    public UnAuthorizedException() {
+        super();
+    }
+
+    public UnAuthorizedException(String message) {
+        super(message);
+    }
+
+    public UnAuthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnAuthorizedException(Throwable cause) {
+        super(cause);
+    }
+
+    protected UnAuthorizedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/ssgssak/ssgpointuser/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/ssgssak/ssgpointuser/global/config/jwt/JwtAuthenticationFilter.java
@@ -30,6 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         final String authHeader = request.getHeader("Authorization"); // 토큰을 받아오는 필드는, request 헤더에서 "Authorization"임
         final String jwt;
+        final String loginId; // loginId를 토큰에서 가져옴
         final String uuid; // uuid를 토큰에서 가져올것임
 
         // 헤더가 null이거나, "Bearer"로 시작하지 않는다면 토큰 인증을 진행하지 않음
@@ -40,11 +41,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 토큰 인증 진행
         jwt = authHeader.substring(7); // "Bearer " 뒷부분이 모두 jwt 토큰임
+        loginId = jwtTokenProvider.getLoginId(jwt); // 토큰에서 loginId추출
         uuid = jwtTokenProvider.getUUID(jwt);    // 토큰에서 uuid를 추출
 
-        // 만약 uuid가 null이 아니고, SecurityContextHolder에 authentication이 없고, 토큰이 유효성 검사를 통과했다면 authentication 생성
-        if (uuid != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            CustomUserDetails userDetails = this.customUserDetailsService.loadUserByUsername(uuid);
+        // 만약 loginId가 null이 아니고, SecurityContextHolder에 authentication이 없고, 토큰이 유효성 검사를 통과했다면 authentication 생성
+        if (loginId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            CustomUserDetails userDetails = this.customUserDetailsService.loadUserByUsername(loginId);
             // 토큰이 유효하다면 authentication 생성
             if (jwtTokenProvider.validateToken(jwt, userDetails)) {
                 // todo: 그냥 authentication 생성하는걸로 이해했는데 맞는지 확인, 그리고 credentials가 뭔지 확인

--- a/src/main/java/ssgssak/ssgpointuser/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/ssgssak/ssgpointuser/global/config/jwt/JwtTokenProvider.java
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
 
     // 4. 토큰 key 디코드 : env에 저장된 키로, 들어온 토큰을 파싱
     private Key getSigningKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(env.getProperty("JWT.SECRET_KEY"));
+        byte[] keyBytes = Decoders.BASE64.decode(env.getProperty("JWT.SECRET_KEY", String.class));
         return Keys.hmacShaKeyFor(keyBytes);
     }
 

--- a/src/main/java/ssgssak/ssgpointuser/global/config/security/ApplicationConfig.java
+++ b/src/main/java/ssgssak/ssgpointuser/global/config/security/ApplicationConfig.java
@@ -39,7 +39,8 @@ public class ApplicationConfig {
     }
 
     // 패스워드 인코더 : 패스워드를 해싱한다
-    private PasswordEncoder passwordEncoder() {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/ssgssak/ssgpointuser/global/config/security/SecurityConfig.java
+++ b/src/main/java/ssgssak/ssgpointuser/global/config/security/SecurityConfig.java
@@ -30,13 +30,14 @@ public class SecurityConfig {
         http
                 // Restful API를 사용하므로, csrf는 사용할 필요가 없다
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.disable())
                 // cors는 사용할것이므로 CorsConfig만 @Configuration 등록하고 따로 설정해주지는 않음
                 // 토큰 방식을 사용하므로, 서버에서 session을 관리하지 않음. 따라서 STATELESS로 설정
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 인증 절차에 대한 설정을 시작 : 필터를 적용시키지 않을 url과, 적용시킬 url을 구분
                 .authorizeHttpRequests(authorizeHttpRequest -> authorizeHttpRequest
-                        .requestMatchers("/api/v1/**", "/swagger-ui/**", "/swagger-resources/**", "/api-docs/**")
+                        .requestMatchers("/api/v1/auth/sign-up","/api/v1/auth/log-in", "/swagger-ui/**", "/swagger-resources/**", "/api-docs/**")
                         .permitAll() // 위의 url은 모두 filter를 거치지 않음
                         .anyRequest().authenticated()) // 위의 url을 제외한 모든 url은 필터를 거쳐야함
                 // 폼 로그인 사용 안함


### PR DESCRIPTION
# 변경점 👍
- login 기능 개발 
     - auth 도메인 : AuthServiceImpl에서 로그인 기능 개발, 회원가입 기능에서 비밀번호 해싱 기능 개발, 로그인시 토큰 return, CustomUserDetailsService에서 loginId로 조회하도록 변경
     - security : applicationConfig의 passwordEncoder를 public으로 설정했는데, 추후 private로 바꿀 예정 
- 이후 인증 실패하는 버그 해결

# 버그 해결 💊
 - jwt : tokenProvider에서, getLoginId를 생성해서 jwtFilter에서 login아이디로 loadUserByUsername을 수행하도록 변경
- security : securityConfig에서 cors 비활성화 및 sign-up,log-in을 제외한 모든 request는 인증을 진행하도록 변경
- auth : userDetails에는 getUsername이 userId를 반환하도록 변경 및 getUserUUID를 생성
       userDetailsService에는 uuid가 아닌 loginID를 받아서 사용하도록 변경
 
