### PR TITLE
refactor: 포인트를 선물하거나 받을 때, 생성날짜가 아닌 포인트id로 검색하도록 변경

### DIFF
--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/application/GiftPointService.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/application/GiftPointService.java
@@ -21,10 +21,10 @@ public interface GiftPointService {
     void giveGiftPoint(GiftPointRequestDto requestDto, String uuid);
 
     // 3. 포인트 선물받기
-    void acceptGiftPoint(GiftPointAcceptDto responseDto, String uuid);
+    void acceptGiftPoint(GiftPointAcceptRequestDto responseDto, String uuid);
 
     // 4. 포인트 선물받기(거절)
-    void refuseGiftPoint(GiftPointRefuseDto refuseDto, String uuid);
+    void refuseGiftPoint(GiftPointRefuseRequestDto refuseDto, String uuid);
 
     // 5. 포인트 선물 대기리스트 조회
     GiftPointWaitListDto getGiftWaitList(String uuid);

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointAcceptRequestDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointAcceptRequestDto.java
@@ -1,18 +1,15 @@
 package ssgssak.ssgpointuser.domain.giftpoint.dto;
 
 import lombok.*;
-import ssgssak.ssgpointuser.domain.giftpoint.entity.GiftStatus;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class GiftPointAcceptDto {
+public class GiftPointAcceptRequestDto {
     private String receiverUUID;
-    private LocalDateTime createAt;
+    private Long giftPointId;
     private Long givePointId;
     private Long receivePointId;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointGetRequestDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointGetRequestDto.java
@@ -1,9 +1,6 @@
 package ssgssak.ssgpointuser.domain.giftpoint.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +8,8 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class GiftPointGetRequestDto {
     private Boolean used;
-    private LocalDateTime createAt;
+    private Long pointId; // used == true라면 pointId는 givePointId, used==false라면 uuid는 receivePointId
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointGetResponseDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointGetResponseDto.java
@@ -1,16 +1,17 @@
 package ssgssak.ssgpointuser.domain.giftpoint.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import ssgssak.ssgpointuser.domain.giftpoint.entity.GiftStatus;
+
+import java.time.LocalDateTime;
 
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@ToString
 public class GiftPointGetResponseDto {
     private String message;
     private String userUUID;
+    private LocalDateTime updateAt;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointRefuseRequestDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/dto/GiftPointRefuseRequestDto.java
@@ -5,13 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GiftPointRefuseDto {
+public class GiftPointRefuseRequestDto {
     private String receiverUUID;
-    private LocalDateTime createAt;
+    private Long giftPointId;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/infrastructure/GiftPointRepository.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/infrastructure/GiftPointRepository.java
@@ -12,20 +12,20 @@ import java.util.Optional;
 @Repository
 public interface GiftPointRepository extends JpaRepository<GiftPoint, Long> {
     /**
-     * 1. receiverUUID, createAt으로, giftPoint 조회
+     * 1. receiverUUID, receivePointId 로, giftPoint 조회
      * 2. receiverUUID, success로, giftPoint 조회
-     * 3. giverUUID, createAt으로, giftPoint 조회
+     * 3. giverUUID, givePointId 로, giftPoint 조회
      * 4.
      */
 
-    // 1. receiverUUID, createAt으로, 선물 조회
-    Optional<GiftPoint> findByReceiverUUIDAndCreateAt(String receiverUUID, LocalDateTime createAt);
+    // 1. receiverUUID, receivePointId 로, 선물 조회
+    Optional<GiftPoint> findByReceiverUUIDAndReceivePointId(String receiverUUID, Long receivePointId);
 
     // 2. receiverUUID, success로, giftPoint 조회
     List<GiftPoint> findByReceiverUUIDAndStatusOrderByCreateAtAsc(String uuid, GiftStatus status);
 
     // 3. giverUUID, createAt으로, 선물 조회
-    Optional<GiftPoint> findByGiverUUIDAndCreateAt(String uuid, LocalDateTime createAt);
+    Optional<GiftPoint> findByGiverUUIDAndGivePointId(String uuid, Long givePointId);
 
 
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/presentation/GiftPointController.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/presentation/GiftPointController.java
@@ -39,13 +39,13 @@ public class GiftPointController {
     // 2. 포인트 선물받기(수락)
     @PutMapping("/accept")
     public void acceptGiftPoint(@RequestBody GiftPointAcceptInVo acceptInVo, Principal principal) {
-        giftPointService.acceptGiftPoint(modelMapper.map(acceptInVo, GiftPointAcceptDto.class), principal.getName());
+        giftPointService.acceptGiftPoint(modelMapper.map(acceptInVo, GiftPointAcceptRequestDto.class), principal.getName());
     }
 
     // 3. 포인트 선물받기(거절)
     @PutMapping("/refuse")
     public void refuseGiftPoint(@RequestBody GiftPointRefuseInVo refuseInVo, Principal principal) {
-        giftPointService.refuseGiftPoint(modelMapper.map(refuseInVo, GiftPointRefuseDto.class), principal.getName());
+        giftPointService.refuseGiftPoint(modelMapper.map(refuseInVo, GiftPointRefuseRequestDto.class), principal.getName());
     }
 
     // 4. 포인트 선물 대기리스트 조회
@@ -57,7 +57,7 @@ public class GiftPointController {
 
     // 5. 선물 포인트 조회
     @GetMapping("")
-    public ResponseEntity<GiftPointGetOutVo> getGiftPoint(@RequestParam GiftPointGetInVo getInVo, Principal principal) {
+    public ResponseEntity<GiftPointGetOutVo> getGiftPoint(GiftPointGetInVo getInVo, Principal principal) {
         GiftPointGetResponseDto requestDto = giftPointService.getGiftList(modelMapper.map(getInVo, GiftPointGetRequestDto.class), principal.getName());
         GiftPointGetOutVo getOutVo = modelMapper.map(requestDto, GiftPointGetOutVo.class);
         return new ResponseEntity<>(getOutVo, HttpStatus.OK);

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointAcceptInVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointAcceptInVo.java
@@ -9,11 +9,9 @@ import java.time.LocalDateTime;
 @Getter
 @ToString
 public class GiftPointAcceptInVo {
+    private Long giftPointId;
     private Long givePointId;
     private Long receivePointId;
-
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime createAt;
 }
 
 

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointGetInVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointGetInVo.java
@@ -1,5 +1,6 @@
 package ssgssak.ssgpointuser.domain.giftpoint.vo;
 
+import jakarta.validation.constraints.Null;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -8,6 +9,10 @@ import java.time.LocalDateTime;
 @Getter
 public class GiftPointGetInVo {
     private Boolean used;
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime createAt;
+    private Long pointId; // used == true라면 pointId는 givePointId, used==false라면 uuid는 receivePointId
+
+    public GiftPointGetInVo(Boolean used, Long pointId) {
+        this.used = used;
+        this.pointId = pointId;
+    }
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointGetOutVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointGetOutVo.java
@@ -1,4 +1,12 @@
 package ssgssak.ssgpointuser.domain.giftpoint.vo;
 
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class GiftPointGetOutVo {
+    private String message;
+    private String userUUID;
+    private LocalDateTime updateAt;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointRefuseInVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/giftpoint/vo/GiftPointRefuseInVo.java
@@ -7,6 +7,5 @@ import java.time.LocalDateTime;
 
 @Getter
 public class GiftPointRefuseInVo {
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime createAt;
+    private Long giftPointId;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/application/PointService.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/application/PointService.java
@@ -43,7 +43,7 @@ public interface PointService {
     PointIdOutDto pointAddPartner(CreatePointDto pointDto, String uuid);
 
     // 6. 포인트 선물받기(수락) -> 포인트 생성
-    PointGiftAcceptResponseDto receiveGiftPoint(PointGiftAcceptRequestDto requestDto);
+    PointGiftAcceptResponseDto receiveGiftPoint(PointGiftAcceptRequestDto requestDto, String receiverUUID);
 
     // 7. 포인트 전환하기
     PointIdOutDto pointExchange(CreatePointDto pointDto, String uuid);

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/application/PointServiceImpl.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/application/PointServiceImpl.java
@@ -98,8 +98,7 @@ public class PointServiceImpl implements PointService {
 
     // 6. 포인트 선물받기(수락) -> 포인트 생성
     @Override
-    public PointGiftAcceptResponseDto receiveGiftPoint(PointGiftAcceptRequestDto requestDto) {
-        String receiverUUID = requestDto.getReceiverUUID();
+    public PointGiftAcceptResponseDto receiveGiftPoint(PointGiftAcceptRequestDto requestDto, String receiverUUID) {
         String giverUUID = requestDto.getGiverUUID();
 
         // giver 포인트 생성

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/dto/PointGiftAcceptRequestDto.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/dto/PointGiftAcceptRequestDto.java
@@ -11,7 +11,6 @@ import ssgssak.ssgpointuser.domain.point.entity.PointType;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PointGiftAcceptRequestDto {
-    private String receiverUUID;
     private String giverUUID;
     private Integer updatePoint;
     private PointType type = PointType.GIFT;

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/presentation/PointController.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/presentation/PointController.java
@@ -57,9 +57,9 @@ public class PointController {
 
     // 3. 포인트 선물받기 -> 진행이후 선물포인트에 POST, "/gift/accept"로 요청이 들어가는것가지가 한세트임
     @PostMapping("/gift/receive")
-    public ResponseEntity<PointGiftAcceptOutVo> receivePoint(@RequestBody PointGiftAcceptInVo inVo) {
+    public ResponseEntity<PointGiftAcceptOutVo> receivePoint(@RequestBody PointGiftAcceptInVo inVo, Principal principal) {
         PointGiftAcceptResponseDto responseDto = pointService.receiveGiftPoint(
-                modelMapper.map(inVo, PointGiftAcceptRequestDto.class));
+                modelMapper.map(inVo, PointGiftAcceptRequestDto.class), principal.getName());
         PointGiftAcceptOutVo outVo = modelMapper.map(responseDto, PointGiftAcceptOutVo.class);
         return new ResponseEntity<>(outVo, HttpStatus.OK);
     }

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/vo/PointGiftAcceptInVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/vo/PointGiftAcceptInVo.java
@@ -5,7 +5,6 @@ import ssgssak.ssgpointuser.domain.point.entity.PointType;
 
 @Getter
 public class PointGiftAcceptInVo {
-    private String receiverUUID;
     private String giverUUID;
     private Integer updatePoint;
 }

--- a/src/main/java/ssgssak/ssgpointuser/domain/point/vo/PointListInVo.java
+++ b/src/main/java/ssgssak/ssgpointuser/domain/point/vo/PointListInVo.java
@@ -19,9 +19,11 @@ public class PointListInVo {
     private LocalDateTime endDay;
 
     // Setter를 사용하지 않으려면 생성자가 필수이다
-    public PointListInVo(PointType type, Boolean used, LocalDateTime startDay, LocalDateTime endDay) {
+
+    public PointListInVo(PointType type, Boolean used, Boolean isEvent, LocalDateTime startDay, LocalDateTime endDay) {
         this.type = type;
         this.used = used;
+        this.isEvent = isEvent;
         this.startDay = startDay;
         this.endDay = endDay;
     }


### PR DESCRIPTION
 # 리팩토링 🛠
- giftpoint 도메인 : 조회부분에서 createAt이 아닌, pointId로 조회하도록 변경 
- point 도메인 : 포인트 선물 부분에서, UUID를 vo에서 받아오던걸 authentication에서 꺼내오도록 변경 

# 스크린샷 🖼
- pointId로 조회하도록 변경
<img width="594" alt="image" src="https://github.com/ssg-ssak/ssg-ssak-BE-user/assets/108791919/c324d4cc-48a4-4225-aec5-9b0bb0862fa8">
<img width="597" alt="image" src="https://github.com/ssg-ssak/ssg-ssak-BE-user/assets/108791919/650401a6-4502-4f10-a07a-530b9aab3fcb">
 
 
